### PR TITLE
Parallel Execution of Status Getter 

### DIFF
--- a/app/routers/website_authenticated.py
+++ b/app/routers/website_authenticated.py
@@ -14,12 +14,13 @@ router = APIRouter()
 async def root(request: Request):
     html_services_data: list[object] = []
     t0 = time.time()
-    # ToDo: make the get_status call async and do all of them at once using asyncio
+
     coros = [get_status(service.service_name) for service in services_list]
     results = await asyncio.gather(*coros)
+
     print(f"Await Time {time.time() - t0}")
+
     for service_index, service in enumerate(services_list):
-        t1 = time.time()
         status = results[service_index]
 
         if status is None:
@@ -53,8 +54,8 @@ async def root(request: Request):
             service.enabled = status[2]
 
         html_services_data.append(service.dict())
-        print(f"t1 {time.time() - t1}")
-    print(f"t0 {time.time() - t0}")
+
+    print(f"Total Refresh Time {time.time() - t0}")
 
     return templates.TemplateResponse(
         "root.html", {"request": request, "services": html_services_data}

--- a/app/routers/website_authenticated.py
+++ b/app/routers/website_authenticated.py
@@ -1,3 +1,4 @@
+import asyncio
 import time
 
 from fastapi import APIRouter, Request
@@ -14,10 +15,13 @@ async def root(request: Request):
     html_services_data: list[object] = []
     t0 = time.time()
     # ToDo: make the get_status call async and do all of them at once using asyncio
-    for service in services_list:
+    coros = [get_status(service.service_name) for service in services_list]
+    results = await asyncio.gather(*coros)
+    print(f"Await Time {time.time() - t0}")
+    for service_index, service in enumerate(services_list):
         t1 = time.time()
-        status = await get_status(service.service_name)
-        print(f"t1 {time.time() - t1}")
+        status = results[service_index]
+
         if status is None:
             service.status = "not found"
             service.status_class = "service_not_found"
@@ -49,6 +53,7 @@ async def root(request: Request):
             service.enabled = status[2]
 
         html_services_data.append(service.dict())
+        print(f"t1 {time.time() - t1}")
     print(f"t0 {time.time() - t0}")
 
     return templates.TemplateResponse(


### PR DESCRIPTION
Instead of getting all statuses in serial, now we use asyncio gather to run the getters in parallel providing a speedup of at least 2 and potentially up to 10 when comparing to historic load times